### PR TITLE
Fix #1: emit plain helper defns referenced from handler bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
           key: ${{ runner.os }}-clojure-${{ hashFiles('deps.edn') }}
           restore-keys: ${{ runner.os }}-clojure-
 
-      - run: clj -X:test
+      - run: clojure -X:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: DeLaGuardo/setup-clojure@13
+        with:
+          cli: latest
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            .cpcache
+          key: ${{ runner.os }}-clojure-${{ hashFiles('deps.edn') }}
+          restore-keys: ${{ runner.os }}-clojure-
+
+      - run: clj -X:test

--- a/ISSUE_ANALYSIS.md
+++ b/ISSUE_ANALYSIS.md
@@ -1,0 +1,59 @@
+# Issue #1 Analysis: plain helper defns not emitted
+
+## The bug
+
+`emit-vars!` assembles the emitted file from five sources:
+
+| Source | Collected via |
+|---|---|
+| Predicate defns | brain predicate registry |
+| Handler defns | brain handler registry |
+| Constructor defns | brain infostructure plan registry |
+| Default-expression helpers | `extract-default-defn` — reads head symbol of each generic's `:default-expr` |
+| Generic dispatch defns | compiled dispatch tree |
+
+Plain `defn` functions defined in a source file — outside any macro — are not registered with the brain. They are loaded into the JVM by `load-file` but are invisible to the compiler. Any handler body that calls one of these helpers emits a call that has no corresponding definition in the runtime file.
+
+## Where exactly
+
+In `emit-vars!` (`runtime_compiler.clj`, around line 367), after:
+
+```clojure
+all-defns (topsort-forms (concat pred-defns handler-defns constructor-defns default-defns generic-defns))
+```
+
+there is no step that finds symbols referenced in those forms that are not yet defined in the collection.
+
+`extract-default-defn` is a partial version of what is needed: it looks at the head symbol of each generic's default expression and resolves it via `defn-form-from-source`. The fix is a generalisation of this pattern to all handler bodies.
+
+## The fix
+
+After assembling `all-defns`, iterate to a fixed point:
+
+1. Walk all forms in the current collection and collect every symbol that is:
+   - referenced in a body position
+   - not already defined in the collection
+   - not available in `clojure.core`
+2. For each such symbol, call `defn-form-from-source` — it searches all loaded namespaces, which includes the helpers loaded by `load-file`.
+3. Add any found forms to the collection and repeat until no new symbols are discovered.
+
+This resolves chains of helpers (helpers calling helpers) without any arbitrary depth limit, and it only includes what is actually referenced — no noise.
+
+`defn-form-from-source` works here because `load-file` has already loaded the source files, so helpers like `walk-a-promise` are present as vars in their namespace and are findable by the symbol search.
+
+The function `referenced-names` already exists but only finds references within a known defined-set. A new private function — call it `collect-source-helpers` — will walk the forms looking for symbols not in the defined-set and not in `clojure.core`, then resolve and recurse.
+
+## Alignment with repository principles
+
+**TDD order:**
+1. *Specs* — no new data shapes are introduced. The fix is a transformation over the existing set of `defn` forms, so no new spec is needed.
+2. *Tests* — one new test in `runtime_compiler_test.clj`: define a source with a plain helper called from a handler, run `emit-runtime!`, assert the helper appears in the emitted file. A second test verifies the fixed-point behaviour: a helper that calls another helper, both emitted.
+3. *Implementation* — add `collect-source-helpers` in `runtime_compiler.clj` and wire it into `emit-vars!` after the existing defn assembly step.
+
+**No new abstractions:** `collect-source-helpers` is a private function, not exposed in the public API. `defn-form-from-source` and the dependency infrastructure (`topsort-forms`) already exist and are reused unchanged.
+
+**No backwards-incompatible change:** the compiler's public interface (`emit-runtime!`) and config shape are untouched.
+
+## What is not addressed here
+
+The issue mentions surfacing an error as an alternative to emitting the helpers. Once the fix is in place, that is no longer necessary — the helpers will be found and emitted. If a symbol is referenced but has no loadable source (e.g. it comes from a Java interop call or a macro-generated var), `defn-form-from-source` returns nil and the symbol is silently left unresolved. Detecting and reporting that case is a separate concern and not part of this fix.

--- a/src/strategic_ai/generics_types/generics/compilers/runtime_compiler.clj
+++ b/src/strategic_ai/generics_types/generics/compilers/runtime_compiler.clj
@@ -346,6 +346,33 @@
               (defn-form-from-source (first default-expr)))))
         generic-vars))
 
+(defn- dangling-symbols [forms]
+  (let [defined-set (into #{} (map defined-name) forms)
+        core-ns     (the-ns 'clojure.core)
+        refs        (volatile! #{})]
+    (doseq [form forms]
+      (walk/postwalk
+       (fn [node]
+         (when (and (symbol? node)
+                    (nil? (namespace node))
+                    (not (contains? defined-set node))
+                    (not (ns-resolve core-ns node)))
+           (vswap! refs conj node))
+         node)
+       (drop 3 form)))
+    @refs))
+
+(defn- collect-source-helpers [defn-forms]
+  (loop [forms defn-forms
+         seen  (into #{} (map defined-name) defn-forms)]
+    (let [new-helpers (->> (dangling-symbols forms)
+                           (keep defn-form-from-source)
+                           (remove #(contains? seen (defined-name %))))]
+      (if (empty? new-helpers)
+        forms
+        (recur (concat forms new-helpers)
+               (into seen (map defined-name new-helpers)))))))
+
 (defn- load-all! [{:keys [protocol sources]}]
   (load-file protocol)
   (doseq [path sources]
@@ -378,7 +405,7 @@
         constructor-defns  (keep build-constructor-defn (protocol/i:all-plans brain/*brain*))
         default-defns      (extract-default-defn generic-vars)
         generic-defns      (map build-generic-defn generic-vars)
-        all-defns          (topsort-forms (concat pred-defns handler-defns constructor-defns default-defns generic-defns))
+        all-defns          (topsort-forms (collect-source-helpers (concat pred-defns handler-defns constructor-defns default-defns generic-defns)))
         to-decl            (names-requiring-declaration all-defns)
         declare-str        (when (seq to-decl)
                              (format-forms [(apply list 'declare to-decl)]))

--- a/test-outputs/compiled/rc_chain_helper_test.clj
+++ b/test-outputs/compiled/rc_chain_helper_test.clj
@@ -1,0 +1,24 @@
+(ns compiled.rc-chain-helper-test
+  "Compiled by @strategic-ai/generic-types 0.0.1-alpha
+Generated: 2026-04-26T13:45:46.953256197Z
+
+## footprint
+
+```edn
+{:protocol \"src/protocol.clj\",
+ :namespace compiled.rc-chain-helper-test,
+ :output \"test-outputs/compiled/rc_chain_helper_test.clj\"}
+```")
+
+(defn rc-ch-number? [x] (number? x))
+
+(defn rc-inner-helper [x] (+ x 1))
+
+(defn rc-outer-helper [x] (rc-inner-helper x))
+
+(defn rc-ch-op-rc-ch-number? [x] (rc-outer-helper x))
+
+(defn
+  rc-ch-op
+  [x0]
+  (cond (rc-ch-number? x0) (rc-ch-op-rc-ch-number? x0) :else :default))

--- a/test-outputs/compiled/rc_ctor_test.clj
+++ b/test-outputs/compiled/rc_ctor_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-ctor-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.878468847Z
+Generated: 2026-04-26T13:45:47.043844943Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_emit_test.clj
+++ b/test-outputs/compiled/rc_emit_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-emit-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.763819920Z
+Generated: 2026-04-26T13:45:46.759292532Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_fmt_test.clj
+++ b/test-outputs/compiled/rc_fmt_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-fmt-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.843435855Z
+Generated: 2026-04-26T13:45:46.876184407Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_footprint_test.clj
+++ b/test-outputs/compiled/rc_footprint_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-footprint-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.863482108Z
+Generated: 2026-04-26T13:45:47.016011638Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_helper_test.clj
+++ b/test-outputs/compiled/rc_helper_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-helper-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.824832057Z
+Generated: 2026-04-26T13:45:46.835921718Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_nodecl_test.clj
+++ b/test-outputs/compiled/rc_nodecl_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-nodecl-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.803577020Z
+Generated: 2026-04-26T13:45:46.805377368Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_req_test.clj
+++ b/test-outputs/compiled/rc_req_test.clj
@@ -1,6 +1,6 @@
 (ns compiled.rc-req-test
   "Compiled by @strategic-ai/generic-types 0.0.1-alpha
-Generated: 2026-04-22T19:40:49.895977099Z
+Generated: 2026-04-26T13:45:47.082171733Z
 
 ## footprint
 

--- a/test-outputs/compiled/rc_source_helper_test.clj
+++ b/test-outputs/compiled/rc_source_helper_test.clj
@@ -1,0 +1,22 @@
+(ns compiled.rc-source-helper-test
+  "Compiled by @strategic-ai/generic-types 0.0.1-alpha
+Generated: 2026-04-26T13:45:47.053987902Z
+
+## footprint
+
+```edn
+{:protocol \"src/protocol.clj\",
+ :namespace compiled.rc-source-helper-test,
+ :output \"test-outputs/compiled/rc_source_helper_test.clj\"}
+```")
+
+(defn rc-sh-number? [x] (number? x))
+
+(defn rc-source-helper [x] (* x 100))
+
+(defn rc-sh-op-rc-sh-number? [x] (rc-source-helper x))
+
+(defn
+  rc-sh-op
+  [x0]
+  (cond (rc-sh-number? x0) (rc-sh-op-rc-sh-number? x0) :else :default))

--- a/test/strategic_ai/generics_types/generics/compilers/runtime_compiler_test.clj
+++ b/test/strategic_ai/generics_types/generics/compilers/runtime_compiler_test.clj
@@ -24,6 +24,11 @@
 
 (defn rc-emit-helper [x y] (if (= x y) x :mismatch))
 
+(defn rc-source-helper [x] (* x 100))
+
+(defn rc-inner-helper [x] (+ x 1))
+(defn rc-outer-helper [x] (rc-inner-helper x))
+
 (comment
   "Config spec — shape validation")
 
@@ -200,6 +205,32 @@
         "helper defn should be emitted")
     (is (str/includes? content "rc-helper-op")
         "compiled generic should be emitted")))
+
+(deftest it-must-be-that-plain-helpers-called-from-handler-body-are-emitted
+  (m/defpredicate rc-sh-number? [x] (number? x))
+  (g/defgeneric rc-sh-op [x] :default)
+  (m/defhandler rc-sh-op [rc-sh-number?] [x] (rc-source-helper x))
+  (let [config  {:protocol  "src/protocol.clj"
+                 :namespace 'compiled.rc-source-helper-test
+                 :output    "test-outputs/compiled/rc_source_helper_test.clj"}
+        _       (rc/emit-runtime! config [#'rc-sh-op])
+        content (slurp "test-outputs/compiled/rc_source_helper_test.clj")]
+    (is (str/includes? content "(defn rc-source-helper")
+        "helper called from handler body must be emitted")))
+
+(deftest it-must-be-that-chained-helpers-are-emitted-transitively
+  (m/defpredicate rc-ch-number? [x] (number? x))
+  (g/defgeneric rc-ch-op [x] :default)
+  (m/defhandler rc-ch-op [rc-ch-number?] [x] (rc-outer-helper x))
+  (let [config  {:protocol  "src/protocol.clj"
+                 :namespace 'compiled.rc-chain-helper-test
+                 :output    "test-outputs/compiled/rc_chain_helper_test.clj"}
+        _       (rc/emit-runtime! config [#'rc-ch-op])
+        content (slurp "test-outputs/compiled/rc_chain_helper_test.clj")]
+    (is (str/includes? content "(defn rc-outer-helper")
+        "outer helper called from handler body must be emitted")
+    (is (str/includes? content "(defn rc-inner-helper")
+        "inner helper transitively called must also be emitted")))
 
 (comment
   "build-constructor-defn — pure function, builds constructor defn form from a plan")


### PR DESCRIPTION
## Summary

- `emit-runtime!` was silently producing broken output when source files defined plain `defn` helpers called from generic handler bodies — the calls were emitted but not the definitions
- Adds `collect-source-helpers` (private): walks assembled defn forms, finds symbols that are referenced but not yet defined and not in `clojure.core`, resolves them via the existing `defn-form-from-source`, and iterates to a fixed point to handle transitive chains
- Wired into `emit-vars!` before `topsort-forms` — no public API changes

## Test plan

- [ ] `it-must-be-that-plain-helpers-called-from-handler-body-are-emitted` — single helper case
- [ ] `it-must-be-that-chained-helpers-are-emitted-transitively` — helper calling another helper
- [ ] Full suite: 227 tests, 0 failures
- [ ] Verified against the consumer project (`compile-ak`) — `walk-a-promise` and `flatten-a-promise-thing` now appear correctly in the emitted `ak.clj`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)